### PR TITLE
feat: Add a shortcut keybinding replace click status bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "where-am-i",
   "displayName": "Where Am I?",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "packageManager": "pnpm@7.0.1",
   "description": "Identify your current working folder in status bar",
   "publisher": "antfu",
@@ -27,6 +27,17 @@
         "command": "where-am-i.config",
         "category": "Where Am I",
         "title": "Config the name and color"
+      },
+      {
+        "command": "where-am-i.open",
+        "category": "Where Am I",
+        "title": "Open project lists"
+      }
+    ],
+    "keybindings": [
+      {
+        "command": "where-am-i.open",
+        "key": "ctrl+shift+w"
       }
     ],
     "configuration": {
@@ -91,7 +102,8 @@
     "vscode:prepublish": "npm run build",
     "build": "tsc -p ./",
     "lint": "eslint .",
-    "watch": "tsc -watch -p ./"
+    "watch": "tsc -watch -p ./",
+    "pkg": "vsce package --no-dependencies"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^0.23.0",

--- a/package.json
+++ b/package.json
@@ -27,16 +27,11 @@
         "command": "where-am-i.config",
         "category": "Where Am I",
         "title": "Config the name and color"
-      },
-      {
-        "command": "where-am-i.open",
-        "category": "Where Am I",
-        "title": "Open project lists"
       }
     ],
     "keybindings": [
       {
-        "command": "where-am-i.open",
+        "command": "workbench.action.quickSwitchWindow",
         "key": "ctrl+shift+w"
       }
     ],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -210,6 +210,12 @@ export function activate(context: ExtensionContext) {
     updateStatusBarItem()
   })
 
+  commands.registerCommand('where-am-i.open', async () => {
+    if (!projectName || !projectPath)
+      return
+    commands.executeCommand('workbench.action.quickSwitchWindow')
+  })
+
   workspace.onDidChangeConfiguration(() => {
     updateSubscription()
     updateStatusBarItem()

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -210,12 +210,6 @@ export function activate(context: ExtensionContext) {
     updateStatusBarItem()
   })
 
-  commands.registerCommand('where-am-i.open', async () => {
-    if (!projectName || !projectPath)
-      return
-    commands.executeCommand('workbench.action.quickSwitchWindow')
-  })
-
   workspace.onDidChangeConfiguration(() => {
     updateSubscription()
     updateStatusBarItem()


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Add a shortcut keybinding (default Ctrl+Shift+W) to open the "quickSwitchWindow" selection list for clicking the status bar.

### Linked Issues
 Continued from the previous one #15 ，I improved the code. 


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
